### PR TITLE
Release 1.2.9.beta13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 ## NEXT RELEASE
-- #37 Clear History" disabled in 1.2.9 beta 12
+- TODO
+
+## 1.2.9.beta13
+- #37, #51 Clear History" disabled in 1.2.9 beta 12
+- #50 Use macOS native folder icon for folder and lock icon for pinned items
 
 ## 1.2.9.beta12
 - Wording issue in Beta preferences pane #34 *@tessus*

--- a/Clipy/Supporting Files/Info.plist
+++ b/Clipy/Supporting Files/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.9.beta12</string>
+	<string>1.2.9.beta13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.2.9.beta12</string>
+	<string>1.2.9.beta13</string>
 	<key>Fabric</key>
 	<dict>
 		<key>APIKey</key>


### PR DESCRIPTION
- #37, #51 Clear History" disabled in 1.2.9 beta 12
- #50 Use macOS native folder icon for folder and lock icon for pinned items